### PR TITLE
Update slack post bot to include branch detail if provided

### DIFF
--- a/pkg/cmd/slackpostBuilds.go
+++ b/pkg/cmd/slackpostBuilds.go
@@ -24,11 +24,13 @@ var (
 	}
 	pipeline        string
 	pipelineRunName string
+	branch          string
 )
 
 func init() {
 	slackpostBuildsCmd.PersistentFlags().StringVar(&pipeline, "pipeline", "", "The name of the Pipeline that failed")
 	slackpostBuildsCmd.PersistentFlags().StringVar(&pipelineRunName, "prun", "", "The name of the PipelineRun that failed")
+	slackpostBuildsCmd.PersistentFlags().StringVar(&branch, "branch", "", "The name of the branch that was being built")
 
 	slackpostBuildsCmd.MarkPersistentFlagRequired("pipeline")
 	slackpostBuildsCmd.MarkPersistentFlagRequired("prun")
@@ -40,7 +42,11 @@ func slackpostBuildsExecute(cmd *cobra.Command, args []string) {
 	fmt.Printf("Galasa Build - Slack Failed Build Report - version %v\n", rootCmd.Version)
 
 	linkToPipelineRun := fmt.Sprintf("http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/#/namespaces/galasa-build/pipelineruns/%s", pipelineRunName)
-	content := fmt.Sprintf("Galasa build pipeline failure:\n\n'%s' pipeline failed.\n\nPlease see %s for details.", pipeline, linkToPipelineRun)
+	branchString := ""
+	if branch != "" {
+		branchString = fmt.Sprintf(" when building the '%s' branch", branch)
+	}
+	content := fmt.Sprintf("Galasa build pipeline failure:\n\n'%s' pipeline failed%s. Please see %s for details.", pipeline, branchString, linkToPipelineRun)
 
 	client := http.Client{
 		Timeout: time.Second * 30,


### PR DESCRIPTION
If branch detail not provided with the --branch flag, which is the case for pipelines that don't really have a branch associated (build github-webhook for example), message is not included, just to keep things concise.