### PR TITLE
updated scripts to use curl and identify the OS and architecture from the machine

### DIFF
--- a/openapi2beans/JavaChecker/build-locally.sh
+++ b/openapi2beans/JavaChecker/build-locally.sh
@@ -43,11 +43,37 @@ warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
 bold() { printf "${bold}%s${reset}\n" "$@" ;}
 note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
+function get_architecture() {
+        raw_os=$(uname -s) # eg: "Darwin"
+    os=""
+    case $raw_os in
+        Darwin*)
+            os="darwin"
+            ;;
+        Linux*)
+            os="linux"
+            ;;
+        *)
+            error "Unsupported operating system is in use. $raw_os"
+            exit 1
+    esac
+
+    architecture=$(uname -m)
+    case $architecture in
+        aarch64)
+            architecture="arm64"
+            ;;
+        x86_64)
+            architecture="amd64"
+    esac
+}
 
 function generate_code() {
     h2 "Generating code..."
 
-    cmd="${BASEDIR}/../bin/openapi2beans-darwin-arm64 generate \
+
+
+    cmd="${BASEDIR}/../bin/openapi2beans-${os}-${architecture} generate \
         --yaml ${BASEDIR}/src/main/resources/test-reference.yaml \
         --output ${BASEDIR}/src/main/java \
         --package dev.galasa.openapi2beans.example.generated \
@@ -67,5 +93,6 @@ function check_code() {
     success "OK"
 }
 
+get_architecture
 generate_code
 check_code

--- a/openapi2beans/JavaChecker/build-locally.sh
+++ b/openapi2beans/JavaChecker/build-locally.sh
@@ -63,8 +63,8 @@ function get_architecture() {
         aarch64)
             architecture="arm64"
             ;;
-        x86_64)
-            architecture="amd64"
+        amd64)
+            architecture="x86_64"
     esac
 }
 

--- a/openapi2beans/build-locally.sh
+++ b/openapi2beans/build-locally.sh
@@ -50,7 +50,7 @@ if [[ -e plantuml.jar ]]; then
 else 
     info "Downloading the plantuml tool..."
     url=https://github.com/plantuml/plantuml/releases/download/v1.2024.3/plantuml-epl-1.2024.3.jar
-    wget $url
+    curl -O $url
     rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to download the plantuml tool jar." ; exit 1 ; fi
     mv plantuml-*.jar plantuml.jar
 fi


### PR DESCRIPTION
## Why?

this changes is needed in order for the openapi2beans build scripts can run on machines other than darwin arm64 machines, so that it can be run by anyone