### PR TITLE
upgraded java in Java checkers pom

### DIFF
--- a/openapi2beans/JavaChecker/pom.xml
+++ b/openapi2beans/JavaChecker/pom.xml
@@ -12,9 +12,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>11</java.version>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<java.version>21</java.version>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 		<unpackBundle>true</unpackBundle>
 	</properties>


### PR DESCRIPTION
# Why
Java is outdated on this branch, upgrading to latest version, relates to: https://github.com/galasa-dev/projectmanagement/issues/1823