### PR TITLE
Openapi2beans needs to handle kebab-case variables in the yaml

### DIFF
--- a/openapi2beans/pkg/generator/JavaStructures.go
+++ b/openapi2beans/pkg/generator/JavaStructures.go
@@ -39,12 +39,12 @@ type JavaClass struct {
 
 func NewJavaClass(name string, description string, javaPackage *JavaPackage, dataMembers []*DataMember, requiredMembers []*RequiredMember, constantDataMembers []*DataMember, hasSerializedNameVar bool) *JavaClass {
 	javaClass := JavaClass{
-		Name:                name,
-		Description:         SplitDescription(description),
-		JavaPackage:         javaPackage,
-		DataMembers:         dataMembers,
-		RequiredMembers:     requiredMembers,
-		ConstantDataMembers: constantDataMembers,
+		Name:                 name,
+		Description:          SplitDescription(description),
+		JavaPackage:          javaPackage,
+		DataMembers:          dataMembers,
+		RequiredMembers:      requiredMembers,
+		ConstantDataMembers:  constantDataMembers,
 		HasSerializedNameVar: hasSerializedNameVar,
 	}
 	javaClass.Sort()
@@ -99,20 +99,24 @@ func NewDataMember(name string, memberType string, description string) *DataMemb
 	if isSnakeCase(name) {
 		serializedOverrideName = name
 	}
-	dataMember := DataMember {
-		Name: utils.StringToCamel(name),
-		PascalCaseName: utils.StringToPascal(name),
-		MemberType: memberType,
-		Description: SplitDescription(description),
+
+	// If the name is kebab-case (eg: my-variable) then lets turn it into
+	// snake-case (eg: my_variable) which we can then turn easily into the other
+	// cases.
+	name = strings.ReplaceAll(name, "-", "_")
+
+	dataMember := DataMember{
+		Name:                   utils.StringToCamel(name),
+		PascalCaseName:         utils.StringToPascal(name),
+		MemberType:             memberType,
+		Description:            SplitDescription(description),
 		SerializedNameOverride: serializedOverrideName,
 	}
 	return &dataMember
 }
 
 func isSnakeCase(name string) bool {
-	var isSnakeCase bool
-	wordArray := strings.Split(name, "_")
-	isSnakeCase = len(wordArray) > 1
+	var isSnakeCase bool = strings.Contains(name, "_") || strings.Contains(name, "-")
 	return isSnakeCase
 }
 
@@ -161,14 +165,14 @@ func stringArrayToEnumValues(stringEnums []string) []EnumValue {
 	for _, value := range stringEnums {
 		var constantFormatName string
 		var stringFormat string
-		if value != "nil"{
+		if value != "nil" {
 			constantFormatName = utils.StringToScreamingSnake(value)
 			stringFormat = value
-			enumValue := EnumValue {
+			enumValue := EnumValue{
 				ConstFormatName: constantFormatName,
-				StringFormat: stringFormat,
+				StringFormat:    stringFormat,
 			}
-			
+
 			enumValues = append(enumValues, enumValue)
 		}
 	}

--- a/openapi2beans/pkg/generator/yaml2java_test.go
+++ b/openapi2beans/pkg/generator/yaml2java_test.go
@@ -979,6 +979,46 @@ components:
 	assert.Contains(t, generatedClassFile, varCreation)
 }
 
+func TestGenerateFilesProducesClassWithDashInPropertyName(t *testing.T) {
+	// Given...
+	packageName := "generated"
+	mockFileSystem := files.NewMockFileSystem()
+	projectFilepath := "dev/wyvinar"
+	apiFilePath := "test-resources/single-bean.yaml"
+	objectName := "MyBeanName"
+	generatedCodeFilePath := "dev/wyvinar/generated/MyBeanName.java"
+	apiYaml := `openapi: 3.0.3
+components:
+  schemas:
+    MyBeanName:
+      type: object
+      description: A simple example
+      properties:
+        my-string-var:
+          type: string
+`
+	// When...
+	mockFileSystem.WriteTextFile(apiFilePath, apiYaml)
+
+	// When...
+	err := GenerateFiles(mockFileSystem, projectFilepath, apiFilePath, packageName, true)
+
+	// Then...
+	assert.Nil(t, err)
+	generatedClassFile := openGeneratedFile(t, mockFileSystem, generatedCodeFilePath)
+	assertClassFileGeneratedOk(t, generatedClassFile, objectName)
+	getter := `public String getMyStringVar() {
+        return this.myStringVar;
+    }`
+	setter := `public void setMyStringVar(String myStringVar) {
+        this.myStringVar = myStringVar;
+    }`
+	varCreation := `private String myStringVar;`
+	assert.Contains(t, generatedClassFile, getter)
+	assert.Contains(t, generatedClassFile, setter)
+	assert.Contains(t, generatedClassFile, varCreation)
+}
+
 func TestGenerateFilesProducesClassWithReferencedArrayProperty(t *testing.T) {
 	// Given...
 	packageName := "generated"


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?

kebab-case is something we want in our rest api for property names.

The openapi2beans tool can handle underscore-separated variables fine, we just need it to do the same thing for dash-separated variables.

eg: my-string-var should be handled the same was as my_string_var is today.
