### PR TITLE
Fixes to allow gson to correctly serialise constants and enums

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,7 +75,18 @@
       "name": "TwilioKeyDetector"
     }
   ],
-  "results": {},
+  "results": {
+    "certificates/ibminter.pem": [
+      {
+        "hashed_secret": "b3723414cb4a90ac8c2bc504ea01923fe5fccc8a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Artifactory Credentials",
+        "verified_result": null
+      }
+    ]
+  },
   "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,

--- a/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestAnEnumProperty.java
+++ b/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestAnEnumProperty.java
@@ -23,7 +23,7 @@ public class TestAnEnumProperty {
         BeanWithEnumPropertyAnEnumProperty enumUnderTest = BeanWithEnumPropertyAnEnumProperty.STRING_1;
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String serialisedForm = gson.toJson(enumUnderTest);
-        assertThat(serialisedForm).contains("\"STRING_1\"");
+        assertThat(serialisedForm).contains("\"string1\"");
     }
 
     @Test
@@ -31,6 +31,6 @@ public class TestAnEnumProperty {
         BeanWithEnumPropertyAnEnumProperty enumUnderTest = BeanWithEnumPropertyAnEnumProperty.STRING_2;
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String serialisedForm = gson.toJson(enumUnderTest);
-        assertThat(serialisedForm).contains("\"STRING_2\"");
+        assertThat(serialisedForm).contains("\"string2\"");
     }
 }

--- a/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestBeanWithEnumProperty.java
+++ b/openapi2beans/JavaChecker/src/test/java/dev/galasa/openapi2beans/example/TestBeanWithEnumProperty.java
@@ -24,6 +24,6 @@ public class TestBeanWithEnumProperty {
         BeanWithEnumProperty beanUnderTest = new BeanWithEnumProperty(enumProperty);
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String serialisedForm = gson.toJson(beanUnderTest);
-        assertThat(serialisedForm).contains("\"anEnumProperty\": \"STRING_1\"");
+        assertThat(serialisedForm).contains("\"anEnumProperty\": \"string1\"");
     }
 }

--- a/openapi2beans/pkg/embedded/templates/JavaClassTemplate.mustache
+++ b/openapi2beans/pkg/embedded/templates/JavaClassTemplate.mustache
@@ -32,10 +32,10 @@ public class {{Name}} {
     {{#Description}}
     // {{&.}}
     {{/Description}}
-    public static final {{MemberType}} {{Name}}{{#ConstantVal}} = {{&.}}{{/ConstantVal}};
+    public final {{MemberType}} {{Name}}{{#ConstantVal}} = {{&.}}{{/ConstantVal}};
     {{/ConstantDataMembers}}
 
-    public {{Name}} ({{#RequiredMembers}}{{^IsFirst}}, {{/IsFirst}}{{DataMember.MemberType}} {{DataMember.Name}}{{/RequiredMembers}}) {
+    public {{Name}}({{#RequiredMembers}}{{^IsFirst}}, {{/IsFirst}}{{DataMember.MemberType}} {{DataMember.Name}}{{/RequiredMembers}}) {
         {{#RequiredMembers}}
         this.{{DataMember.Name}} = {{DataMember.Name}};
         {{/RequiredMembers}}

--- a/openapi2beans/pkg/embedded/templates/JavaEnumTemplate.mustache
+++ b/openapi2beans/pkg/embedded/templates/JavaEnumTemplate.mustache
@@ -5,12 +5,16 @@
  */
 package {{JavaPackage.Name}};
 
+import com.google.gson.annotations.SerializedName;
+
 {{#Description}}
 // {{&.}}
 {{/Description}}
 public enum {{Name}} {
     {{#EnumValues}}
-    {{ConstFormatName}}{{#StringFormat}} ("{{&.}}"){{/StringFormat}}{{^IsFinal}},{{/IsFinal}}{{#IsFinal}};{{/IsFinal}}
+    {{#StringFormat}}@SerializedName("{{&.}}"){{/StringFormat}}
+    {{ConstFormatName}}{{#StringFormat}}("{{&.}}"){{/StringFormat}}{{^IsFinal}},
+{{/IsFinal}}{{#IsFinal}};{{/IsFinal}}
     {{/EnumValues}}
 
     private final String outputName;

--- a/openapi2beans/pkg/generator/package2java_test.go
+++ b/openapi2beans/pkg/generator/package2java_test.go
@@ -56,7 +56,7 @@ func openGeneratedFile(t *testing.T, mockFileSystem files.FileSystem, generatedC
 func assertClassFileGeneratedOk(t *testing.T, generatedFile string, className string) {
 	assert.Contains(t, generatedFile, "package "+TARGET_JAVA_PACKAGE)
 	assert.Contains(t, generatedFile, "public class "+className)
-	assert.Contains(t, generatedFile, "public "+className+" (")
+	assert.Contains(t, generatedFile, "public "+className+"(")
 }
 
 func assertVariablesGeneratedOk(t *testing.T, generatedFile string, dataMembers []*DataMember) {
@@ -74,7 +74,7 @@ func assertVariablesGeneratedOk(t *testing.T, generatedFile string, dataMembers 
 
 func assertConstantsGeneratedOk(t *testing.T, generatedFile string, constDataMembers []*DataMember) {
 	for _, constDataMember := range constDataMembers {
-		assert.Contains(t, generatedFile, "public static final "+constDataMember.MemberType+" "+constDataMember.Name+" = "+constDataMember.ConstantVal)
+		assert.Contains(t, generatedFile, "public final "+constDataMember.MemberType+" "+constDataMember.Name+" = "+constDataMember.ConstantVal)
 		for _, line := range constDataMember.Description {
 			assert.Contains(t, generatedFile, "// "+line)
 		}
@@ -344,7 +344,7 @@ func TestPackageStructParsesToTemplateWithClassWithRequiredProperty(t *testing.T
 	generatedFile := openGeneratedFile(t, mockFileSystem, generatedCodeFilePath)
 	assertClassFileGeneratedOk(t, generatedFile, className)
 	assertVariablesGeneratedOk(t, generatedFile, dataMembers)
-	constructor := `public MyBean (String RandMember1) {
+	constructor := `public MyBean(String RandMember1) {
         this.RandMember1 = RandMember1;
     }`
 	assert.Contains(t, generatedFile, constructor)

--- a/openapi2beans/pkg/generator/package2java_test.go
+++ b/openapi2beans/pkg/generator/package2java_test.go
@@ -84,7 +84,7 @@ func assertConstantsGeneratedOk(t *testing.T, generatedFile string, constDataMem
 func assertEnumFileGeneratedOk(t *testing.T, generatedFile string, javaEnum *JavaEnum) {
 	assert.Contains(t, generatedFile, "package "+TARGET_JAVA_PACKAGE)
 	assert.Contains(t, generatedFile, "public enum "+javaEnum.Name)
-	valueTemplate := `%s ("%s"),`
+	valueTemplate := `%s("%s"),`
 	
 	for _, value := range javaEnum.EnumValues {
 		assert.Contains(t, generatedFile, fmt.Sprintf(valueTemplate, value.ConstFormatName, value.StringFormat))

--- a/openapi2beans/pkg/generator/yaml2java_test.go
+++ b/openapi2beans/pkg/generator/yaml2java_test.go
@@ -846,8 +846,11 @@ components:
     }`)
 	generatedEnumFile := openGeneratedFile(t, mockFileSystem, "dev/wyvinar/generated/MyBeanNameMyEnum.java")
 	expectedEnumFile := `public enum MyBeanNameMyEnum {
-    STRING_1 ("string1"),
-    STRING_2 ("string2");
+    @SerializedName("string1")
+    STRING_1("string1"),
+
+    @SerializedName("string2")
+    STRING_2("string2");
 
     %s
 }`
@@ -897,7 +900,8 @@ components:
     }`)
 	generatedEnumFile := openGeneratedFile(t, mockFileSystem, "dev/wyvinar/generated/MyBeanNameMyEnum.java")
 	expectedEnumFile := `public enum MyBeanNameMyEnum {
-    RAND_VALUE_1 ("randValue1");
+    @SerializedName("randValue1")
+    RAND_VALUE_1("randValue1");
 
     %s
 }`

--- a/openapi2beans/pkg/generator/yaml2java_test.go
+++ b/openapi2beans/pkg/generator/yaml2java_test.go
@@ -410,7 +410,7 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	assert.Contains(t, generatedClassFile, `    public MyBeanName (String myStringVar) {
+	assert.Contains(t, generatedClassFile, `    public MyBeanName(String myStringVar) {
         this.myStringVar = myStringVar;
     }`)
 }
@@ -469,7 +469,7 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	assert.Contains(t, generatedClassFile, `    public MyBeanName (int myIntVar, String myStringVar) {
+	assert.Contains(t, generatedClassFile, `    public MyBeanName(int myIntVar, String myStringVar) {
         this.myIntVar = myIntVar;
         this.myStringVar = myStringVar;
     }`)
@@ -529,7 +529,7 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	assert.Contains(t, generatedClassFile, `    public MyBeanName (String myStringVar) {
+	assert.Contains(t, generatedClassFile, `    public MyBeanName(String myStringVar) {
         this.myStringVar = myStringVar;
     }`)
 }
@@ -841,7 +841,7 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	assert.Contains(t, generatedClassFile, `    public MyBeanName (MyBeanNameMyEnum myEnum) {
+	assert.Contains(t, generatedClassFile, `    public MyBeanName(MyBeanNameMyEnum myEnum) {
         this.myEnum = myEnum;
     }`)
 	generatedEnumFile := openGeneratedFile(t, mockFileSystem, "dev/wyvinar/generated/MyBeanNameMyEnum.java")
@@ -893,7 +893,7 @@ components:
 	assert.Contains(t, generatedClassFile, getter)
 	assert.Contains(t, generatedClassFile, setter)
 	assert.Contains(t, generatedClassFile, varCreation)
-	assert.Contains(t, generatedClassFile, `    public MyBeanName () {
+	assert.Contains(t, generatedClassFile, `    public MyBeanName() {
     }`)
 	generatedEnumFile := openGeneratedFile(t, mockFileSystem, "dev/wyvinar/generated/MyBeanNameMyEnum.java")
 	expectedEnumFile := `public enum MyBeanNameMyEnum {
@@ -933,7 +933,7 @@ components:
 	assert.Nil(t, err)
 	generatedClassFile := openGeneratedFile(t, mockFileSystem, generatedCodeFilePath)
 	assertClassFileGeneratedOk(t, generatedClassFile, objectName)
-	constAssignment := `public static final String MY_CONST_VAR = "constVal"`
+	constAssignment := `public final String MY_CONST_VAR = "constVal"`
 	assert.Contains(t, generatedClassFile, constAssignment)
 }
 


### PR DESCRIPTION
## Why?
Related to findings as part of https://github.com/galasa-dev/projectmanagement/issues/1467

Currently, generated Java bean classes declare constants as static fields, but gson doesn't serialise static fields, so the resulting JSON doesn't include these constants.

When converting an enum value to JSON, it doesn't use the enum's human-readable string values and instead, uses the enum's constant value as it is declared.

## Changes
- Changed declaration of constants to non-static fields (i.e. `public final String MY_CONSTANT = "ConstantValue"`) so that gson can serialise such fields
- Added `@SerializedName` annotations to generated enum values so that enums are correctly serialised into their string representations
  - For example, given an enum value `USERNAME_PASSWORD("UsernamePassword")` converting this value to JSON will be rendered as `UsernamePassword` instead of `USERNAME_PASSWORD`
- Removed space in generated constructors (e.g. `public MyBean ()` now becomes `public MyBean()`)
- Removed space after enum values (e.g. `MY_VALUE ("MyValue")` now becomes `MY_VALUE("MyValue")`)